### PR TITLE
Dashboard de empleador, general y por empresa

### DIFF
--- a/Tests/ProjectServicesTests.cs
+++ b/Tests/ProjectServicesTests.cs
@@ -64,7 +64,7 @@ namespace backend.Tests
             )).ReturnsAsync(expectedDirectionId);
             _projectRepoMock.Setup(r => r.CreateAsync(It.IsAny<Project>()))
                           .ReturnsAsync(expectedProjectResponse);
-            _directionRepoMock.Setup(r => r.GetDireccionByIdAsync(expectedDirectionId))
+            _directionRepoMock.Setup(r => r.GetDirectionByIdAsync(expectedDirectionId))
                             .ReturnsAsync(expectedDirection);
 
             // Act
@@ -388,7 +388,7 @@ namespace backend.Tests
                           .ReturnsAsync(1);
             _projectRepoMock.Setup(r => r.CreateAsync(It.IsAny<Project>()))
                           .ReturnsAsync(expectedProjectResponse);
-            _directionRepoMock.Setup(r => r.GetDireccionByIdAsync(It.IsAny<int>()))
+            _directionRepoMock.Setup(r => r.GetDirectionByIdAsync(It.IsAny<int>()))
                             .ReturnsAsync(new DirectionDTO());
 
             // Act

--- a/backend/Controllers/ProjectController.cs
+++ b/backend/Controllers/ProjectController.cs
@@ -288,5 +288,39 @@ namespace backend.Controllers
 
             return Ok(result.Project);
         }
+
+        // GET DASHBOARD METRICS FOR THE PROJECT (INDIVIDUALLY) DASHBOARD
+        [HttpGet("{projectId}/dashboard/metrics")]
+        public async Task<ActionResult<DashboardMetricsDTO>> GetDashboardMetrics(int projectId)
+        {
+            try
+            {
+                _logger.LogInformation("Obteniendo métricas de dashboard para el proyecto {ProjectId}", projectId);
+
+                var metrics = await _projectService.GetDashboardMetricsAsync(projectId);
+
+                if (metrics == null)
+                {
+                    return NotFound(new { message = "No se encontraron métricas para el proyecto especificado" });
+                }
+
+                _logger.LogInformation("Métricas obtenidas exitosamente para el proyecto {ProjectId}", projectId);
+                return Ok(metrics);
+            }
+            catch (ArgumentException ex)
+            {
+                _logger.LogWarning("Argumento inválido para proyecto {ProjectId}: {Message}", projectId, ex.Message);
+                return BadRequest(new { message = ex.Message });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error interno obteniendo métricas para el proyecto {ProjectId}", projectId);
+                return StatusCode(500, new
+                {
+                    message = ReturnMessagesConstants.General.InternalServerError,
+                    detail = ex.Message
+                });
+            }
+        }
     }
 }

--- a/backend/Controllers/ProjectController.cs
+++ b/backend/Controllers/ProjectController.cs
@@ -77,6 +77,26 @@ namespace backend.Controllers
             }
         }
 
+        // GET THE PROJECT'S DIRECTION BY DIRECTION ID
+        [HttpGet("direction/{directionId}")]
+        public async Task<ActionResult<DirectionDTO>> GetDirectionById(int directionId)
+        {
+            try
+            {
+                var direction = await _projectService.GetProjectDirectionByDirectionId(directionId);
+                if (direction == null)
+                {
+                    return NotFound(new { message = "Dirección no encontrada" });
+                }
+
+                return Ok(direction);
+            }
+            catch (Exception ex)
+            {
+                return StatusCode(500, new { message = "Error al obtener la dirección", error = ex.Message });
+            }
+        }
+
         [HttpGet("dashboard/{employerId}")]
         public async Task<ActionResult<List<ProjectResponseDTO>>> GetProjectsForDashboard(int employerId)
         {

--- a/backend/DTOs/EmployeeDTOs.cs
+++ b/backend/DTOs/EmployeeDTOs.cs
@@ -10,8 +10,9 @@ namespace backend.DTOs
         public int? Telefono { get; set; }
         public string Puesto { get; set; } = string.Empty;
         public string Departamento { get; set; } = string.Empty;
-        public int Salario { get; set; }
+        public int? Salario { get; set; }
         public string TipoContrato { get; set; } = string.Empty;
+        public string Estado { get; set; } = string.Empty;
     }
 
     public class EmployeeListResponseDto

--- a/backend/DTOs/ProjectDTOs.cs
+++ b/backend/DTOs/ProjectDTOs.cs
@@ -149,4 +149,19 @@ namespace backend.DTOs
     public class ProjectListDto : ProjectResponseDTO { }
     public class CompanyDashboardMainEmployerDto : ProjectResponseDTO { }
     public class DashboardMainEmployerDto : ProjectResponseDTO { }
+
+    public class DashboardMetricsDTO
+    {
+        public int TotalEmployees { get; set; }
+        public decimal CurrentPayroll { get; set; }
+        public int ActiveDepartments { get; set; }
+        public int Notifications { get; set; }
+    }
+
+    public class DepartmentStatsDTO
+    {
+        public string DepartmentName { get; set; } = string.Empty;
+        public int EmployeeCount { get; set; }
+        public decimal TotalSalary { get; set; }
+    }
 }

--- a/backend/Repositories/DirectionRepository.cs
+++ b/backend/Repositories/DirectionRepository.cs
@@ -44,7 +44,7 @@ namespace backend.Repositories
             }
         }
 
-        public async Task<DirectionDTO?> GetDireccionByIdAsync(int id)
+        public async Task<DirectionDTO?> GetDirectionByIdAsync(int id)
         {
             try
             {

--- a/backend/Repositories/EmployeeRepository.cs
+++ b/backend/Repositories/EmployeeRepository.cs
@@ -241,7 +241,8 @@ namespace backend.Repositories
                     e.Puesto,
                     e.Departamento,
                     e.Salario,
-                    e.TipoContrato
+                    e.TipoContrato,
+                    e.Estado
                 FROM PlaniFy.Empleado e
                 INNER JOIN PlaniFy.Persona p ON p.Id = e.idPersona
                 WHERE e.idEmpresa = @CompanyId

--- a/backend/Repositories/IDirectionRepository.cs
+++ b/backend/Repositories/IDirectionRepository.cs
@@ -6,7 +6,7 @@ namespace backend.Repositories
     public interface IDirectionRepository
     {
         Task<int> CreateDireccionAsync(string provincia, string canton, string distrito, string? direccionParticular);
-        Task<DirectionDTO?> GetDireccionByIdAsync(int id);
+        Task<DirectionDTO?> GetDirectionByIdAsync(int id);
         Task<bool> UpdateDireccionAsync(int id, DirectionDTO direccion);
     }
 }

--- a/backend/Repositories/IProjectRepository.cs
+++ b/backend/Repositories/IProjectRepository.cs
@@ -8,7 +8,7 @@ namespace backend.Repositories
         Task<List<ProjectResponseDTO>> GetByEmployerIdAsync(int employerId);
         Task<ProjectResponseDTO?> GetByIdAsync(int id);
         Task<List<ProjectResponseDTO>> GetAllAsync();
-        Task<DirectionDTO?> GetDireccionByIdAsync(int id);
+        Task<DirectionDTO?> GetDirectionByIdAsync(int id);
         Task<decimal> GetMonthlyPayrollAsync(int projectId);
         Task<int> CountActiveEmployeesAsync(int projectId);
         Task<ProjectResponseDTO?> GetProjectWithDireccionAsync(int id);

--- a/backend/Repositories/ProjectRepository.cs
+++ b/backend/Repositories/ProjectRepository.cs
@@ -452,9 +452,9 @@ namespace backend.Repositories
             return await _direccionRepository.CreateDireccionAsync(provincia, canton ?? string.Empty, distrito ?? string.Empty, direccionParticular);
         }
 
-        public async Task<DirectionDTO?> GetDireccionByIdAsync(int id)
+        public async Task<DirectionDTO?> GetDirectionByIdAsync(int id)
         {
-            return await _direccionRepository.GetDireccionByIdAsync(id);
+            return await _direccionRepository.GetDirectionByIdAsync(id);
         }
     }
 }

--- a/backend/Services/IProjectService.cs
+++ b/backend/Services/IProjectService.cs
@@ -11,6 +11,8 @@ namespace backend.Services
         Task<ProjectResponseDTO> CreateProjectAsync(CreateProjectDto createProjectDto, int employerId);
         Task<int> GetActiveEmployeesCountAsync(int projectId);
         Task<List<ProjectResponseDTO>> GetProjectsByEmployerIdAsync(int employerId);
+        Task<DirectionDTO?> GetProjectDirectionByDirectionId(int id);
+
 
         // Nuevos métodos para consolidar funcionalidad del dashboard
         Task<List<ProjectResponseDTO>> GetProjectsForDashboardAsync(int employerId);

--- a/backend/Services/IProjectService.cs
+++ b/backend/Services/IProjectService.cs
@@ -11,7 +11,6 @@ namespace backend.Services
         Task<ProjectResponseDTO> CreateProjectAsync(CreateProjectDto createProjectDto, int employerId);
         Task<int> GetActiveEmployeesCountAsync(int projectId);
         Task<List<ProjectResponseDTO>> GetProjectsByEmployerIdAsync(int employerId);
-        Task<DirectionDTO?> GetProjectDirectionByDirectionId(int id);
 
 
         // Nuevos métodos para consolidar funcionalidad del dashboard
@@ -25,5 +24,10 @@ namespace backend.Services
         Task<bool> ExistsByLegalIdAsync(string legalId);
         Task<bool> ExistsByEmailAsync(string email);
         Task<bool> ProjectExistsAsync(int id);
+
+        // DASHBOARD METHODS
+        Task<List<DepartmentStatsDTO>> GetDepartmentStatsAsync(int projectId);
+        Task<DashboardMetricsDTO?> GetDashboardMetricsAsync(int projectId);
+        Task<DirectionDTO?> GetProjectDirectionByDirectionId(int id);
     }
 }

--- a/backend/Services/ProjectService.cs
+++ b/backend/Services/ProjectService.cs
@@ -7,12 +7,12 @@ namespace backend.Services
     public class ProjectService : IProjectService
     {
         private readonly IProjectRepository _projectRepository;
-        private readonly IDirectionRepository _direccionRepository;
+        private readonly IDirectionRepository _directionRepository;
 
         public ProjectService(IProjectRepository projectRepository, IDirectionRepository direccionRepository)
         {
             _projectRepository = projectRepository;
-            _direccionRepository = direccionRepository;
+            _directionRepository = direccionRepository;
         }
 
         // CREATE A PROJECT
@@ -53,7 +53,7 @@ namespace backend.Services
                 UpdatedAt = DateTime.UtcNow
             };
             var createdProject = await _projectRepository.CreateAsync(project);
-            var direccion = await _direccionRepository.GetDireccionByIdAsync(direccionId);
+            var direccion = await _directionRepository.GetDirectionByIdAsync(direccionId);
             return new ProjectResponseDTO
             {
                 Id = createdProject.Id,
@@ -88,6 +88,12 @@ namespace backend.Services
         public async Task<ProjectResponseDTO?> GetProjectByIdAsync(int id)
         {
             return await _projectRepository.GetProjectWithDireccionAsync(id);
+        }
+
+        // GET A PROJECT'S DIRECTION BY DIRECTION ID
+        public async Task<DirectionDTO?> GetProjectDirectionByDirectionId(int id)
+        {
+            return await _directionRepository.GetDirectionByIdAsync(id);
         }
 
         // GET A PROJECTS BY EMPLOYER ID

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/postcss": "^4.1.13",
         "autoprefixer": "^10",
         "axios": "^1.12.2",
+        "chart.js": "^4.5.1",
         "core-js": "^3.8.3",
         "postcss": "^8",
         "router-view": "^1.1.7",
@@ -1942,6 +1943,11 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w=="
     },
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.5",
@@ -4306,6 +4312,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/chokidar": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@tailwindcss/postcss": "^4.1.13",
     "autoprefixer": "^10",
     "axios": "^1.12.2",
+    "chart.js": "^4.5.1",
     "core-js": "^3.8.3",
     "postcss": "^8",
     "router-view": "^1.1.7",

--- a/frontend/src/components/common/MainEmployerHeader.vue
+++ b/frontend/src/components/common/MainEmployerHeader.vue
@@ -42,69 +42,69 @@
 </template>
 
 <script>
-import apiConfig from '../../config/api.js'
+  import apiConfig from '../../config/api.js'
 
-export default {
-  name: 'MainEmployerHeader',
-  data() {
-    return {
-      companies: [],
-      selectedProjectId: '',
-    }
-  },
-  async mounted() {
-    await this.fetchCompanies()
-    this.detectCurrentProject()
-  },
-  methods: {
-    async fetchCompanies() {
-      try {
-        const employerId = localStorage.getItem('employerId')
-        if (!employerId) {
+  export default {
+    name: 'MainEmployerHeader',
+    data() {
+      return {
+        companies: [],
+        selectedProjectId: '',
+      }
+    },
+    async mounted() {
+      await this.fetchCompanies()
+      this.detectCurrentProject()
+    },
+    methods: {
+      async fetchCompanies() {
+        try {
+          const employerId = localStorage.getItem('employerId')
+          if (!employerId) {
+            this.companies = []
+            return
+          }
+          
+          const response = await fetch(apiConfig.endpoints.projectsByEmployer(employerId))
+          if (response.ok) {
+            this.companies = await response.json()
+          }
+        } catch (error) {
           this.companies = []
-          return
         }
-        
-        const response = await fetch(apiConfig.endpoints.projectsByEmployer(employerId))
-        if (response.ok) {
-          this.companies = await response.json()
-        }
-      } catch (error) {
-        this.companies = []
-      }
-    },
-    navigateToHomeLogged() {
-      localStorage.removeItem('selectedProject')
-      this.selectedProjectId = ''
-      this.$router.push('/dashboard-main-employer')
-    },
-    logout() {
-      localStorage.removeItem('user')
-      localStorage.removeItem('token')
-      localStorage.removeItem('selectedProject')
-      this.$router.push('/login')
-    },
-    onProjectChange() {
-      if (this.selectedProjectId) {
-        const selectedProject = this.companies.find(
-          company => company.id == this.selectedProjectId
-        )
-        localStorage.setItem('selectedProject', JSON.stringify(selectedProject))
-        this.$emit('project-changed', selectedProject)
-        this.$router.push({
-          name: 'DashboardProject',
-          params: { id: this.selectedProjectId }
-        })
-      }
-    },
-    detectCurrentProject() {
-      const selectedProject = JSON.parse(localStorage.getItem('selectedProject'))
-      if (selectedProject) {
-        this.selectedProjectId = selectedProject.id
-      } else {
+      },
+      navigateToHomeLogged() {
+        localStorage.removeItem('selectedProject')
         this.selectedProjectId = ''
+        this.$router.push('/dashboard-main-employer')
+      },
+      logout() {
+        localStorage.removeItem('user')
+        localStorage.removeItem('token')
+        localStorage.removeItem('selectedProject')
+        this.$router.push('/login')
+      },
+      onProjectChange() {
+        if (this.selectedProjectId) {
+          const selectedProject = this.companies.find(
+            company => company.id == this.selectedProjectId
+          )
+          localStorage.setItem('selectedProject', JSON.stringify(selectedProject))
+          this.$emit('project-changed', selectedProject)
+          this.$router.push({
+            name: 'DashboardProject',
+            params: { id: this.selectedProjectId }
+          })
+        }
+      },
+      detectCurrentProject() {
+        const selectedProject = JSON.parse(localStorage.getItem('selectedProject'))
+        if (selectedProject) {
+          this.selectedProjectId = selectedProject.id
+        } else {
+          this.selectedProjectId = ''
+        }
       }
     }
   }
-}
 </script>

--- a/frontend/src/components/employer/projectDashboard/DashboardContent.vue
+++ b/frontend/src/components/employer/projectDashboard/DashboardContent.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="body">
+    <div class="space-y-[18px]">
+      <h1 class="text-4xl font-bold text-gray-800">Dashboard de Empresa</h1>
+      <div class="w-full h-[10px] mt-2 rounded neumorphism-on-small-item"></div>
+    </div>
+
+    <!-- Métricas Clave -->
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+      <!-- Total Empleados -->
+      <div class="neumorphism-card text-center">
+        <div class="text-3xl font-bold text-blue-600 mb-2">{{ dashboardData.totalEmployees || 0 }}</div>
+        <div class="text-gray-600 text-sm">Empleados Activos</div>
+      </div>
+
+      <!-- Planilla del Mes -->
+      <div class="neumorphism-card text-center">
+        <div class="text-3xl font-bold text-green-600 mb-2">₡{{ (dashboardData.currentPayroll || 0).toLocaleString() }}</div>
+        <div class="text-gray-600 text-sm">Planilla Actual</div>
+      </div>
+
+      <!-- Departamentos -->
+      <div class="neumorphism-card text-center">
+        <div class="text-3xl font-bold text-purple-600 mb-2">{{ dashboardData.activeDepartments || 0 }}</div>
+        <div class="text-gray-600 text-sm">Departamentos</div>
+      </div>
+
+      <!-- Tareas Pendientes -->
+      <div class="neumorphism-card text-center">
+        <div class="text-3xl font-bold text-orange-600 mb-2">{{ dashboardData.notifications || 0 }}</div>
+        <div class="text-gray-600 text-sm">Notificaciones</div>
+      </div>
+    </div>
+
+    <!-- Información de la Empresa y Acciones Rápidas -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+      <!-- Información de la Empresa -->
+      <div class="neumorphism-card p-6 rounded-2xl">
+        <h2 class="text-xl font-semibold mb-4">Información de la Empresa</h2>
+        <div class="space-y-2">
+          <p class="text-gray-700"><span class="font-bold">Nombre:</span> {{ project.nombre || 'N/A' }}</p>
+          <p class="text-gray-700"><span class="font-bold">Cédula Jurídica:</span> {{ project.cedulaJuridica || 'N/A' }}</p>
+          <p class="text-gray-700"><span class="font-bold">Período de Pago:</span> {{ project.periodoPago || 'N/A' }}</p>
+          <p class="text-gray-700"><span class="font-bold">Email:</span> {{ project.email || 'N/A' }}</p>
+          <p class="text-gray-700"><span class="font-bold">Teléfono:</span> {{ project.telefono || 'N/A' }}</p>
+          <p class="text-gray-700">
+            <span class="font-bold">Dirección:</span> 
+            <span v-if="loadingDirection">Cargando...</span>
+            <span v-else>{{ projectDirection || 'N/A' }}</span>
+          </p>
+        </div>
+      </div>
+
+      <div class="neumorphism-card p-6 rounded-2xl">
+        <h3 class="text-lg font-semibold mb-4">Empleados por Departamento</h3>
+        <div class="h-64 flex items-center justify-center border-2 border-dashed border-gray-300 rounded-lg">
+          <div class="text-center">
+            <div class="text-4xl mb-2">📊</div>
+            <div class="text-gray-500">Gráfico de Donut</div>
+            <div class="text-xs text-gray-400 mt-1">Próximamente</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { apiConfig } from '../../../config/api.js'
+
+export default {
+  name: 'DashboardContent',
+  props: {
+    project: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+  emits: ['section-change'],
+  data() {
+    return {
+      dashboardData: {},
+      projectDirection: null,
+      loadingDirection: false
+    }
+  },
+  watch: {
+    project: {
+      handler(newProject) {
+        if (newProject && newProject.idDireccion) {
+          this.fetchDirection()
+        }
+      },
+      deep: true,
+      immediate: true
+    }
+  },
+  methods: {
+    async fetchDirection() {
+      if (!this.project.idDireccion) {
+        this.projectDirection = null
+        return
+      }
+
+      try {
+        this.loadingDirection = true
+        const response = await fetch(apiConfig.endpoints.projectDirection(this.project.idDireccion))
+        
+        if (!response.ok) {
+          throw new Error(`Error ${response.status}: No se pudo cargar la dirección`)
+        }
+        
+        const direction = await response.json()
+        
+        // Format the complete address
+        this.projectDirection = this.formatAddress(direction)
+        
+        console.log('Direction loaded for project:', this.project.id, direction)
+      } catch (err) {
+        console.error('Error loading direction:', err)
+        this.projectDirection = 'Error al cargar dirección'
+      } finally {
+        this.loadingDirection = false
+      }
+    },
+
+    formatAddress(direction) {
+      if (!direction) return null
+      
+      const parts = []
+      
+      if (direction.provincia) parts.push(direction.provincia)
+      if (direction.canton) parts.push(direction.canton)  
+      if (direction.distrito) parts.push(direction.distrito)
+      if (direction.direccionParticular) parts.push(direction.direccionParticular)
+      
+      return parts.length > 0 ? parts.join(', ') : null
+    }
+  }
+}
+</script>

--- a/frontend/src/components/employer/projectDashboard/DashboardContent.vue
+++ b/frontend/src/components/employer/projectDashboard/DashboardContent.vue
@@ -5,59 +5,194 @@
       <div class="w-full h-[10px] mt-2 rounded neumorphism-on-small-item"></div>
     </div>
 
-    <!-- Métricas Clave -->
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-      <!-- Total Empleados -->
-      <div class="neumorphism-card text-center">
-        <div class="text-3xl font-bold text-blue-600 mb-2">{{ dashboardData.totalEmployees || 0 }}</div>
-        <div class="text-gray-600 text-sm">Empleados Activos</div>
-      </div>
-
-      <!-- Planilla del Mes -->
-      <div class="neumorphism-card text-center">
-        <div class="text-3xl font-bold text-green-600 mb-2">₡{{ (dashboardData.currentPayroll || 0).toLocaleString() }}</div>
-        <div class="text-gray-600 text-sm">Planilla Actual</div>
-      </div>
-
-      <!-- Departamentos -->
-      <div class="neumorphism-card text-center">
-        <div class="text-3xl font-bold text-purple-600 mb-2">{{ dashboardData.activeDepartments || 0 }}</div>
-        <div class="text-gray-600 text-sm">Departamentos</div>
-      </div>
-
-      <!-- Tareas Pendientes -->
-      <div class="neumorphism-card text-center">
-        <div class="text-3xl font-bold text-orange-600 mb-2">{{ dashboardData.notifications || 0 }}</div>
-        <div class="text-gray-600 text-sm">Notificaciones</div>
-      </div>
+    <!-- Loading State -->
+    <div v-if="loadingDashboard" class="flex justify-center items-center py-12">
+      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
     </div>
 
-    <!-- Información de la Empresa y Acciones Rápidas -->
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-      <!-- Información de la Empresa -->
-      <div class="neumorphism-card p-6 rounded-2xl">
-        <h2 class="text-xl font-semibold mb-4">Información de la Empresa</h2>
-        <div class="space-y-2">
-          <p class="text-gray-700"><span class="font-bold">Nombre:</span> {{ project.nombre || 'N/A' }}</p>
-          <p class="text-gray-700"><span class="font-bold">Cédula Jurídica:</span> {{ project.cedulaJuridica || 'N/A' }}</p>
-          <p class="text-gray-700"><span class="font-bold">Período de Pago:</span> {{ project.periodoPago || 'N/A' }}</p>
-          <p class="text-gray-700"><span class="font-bold">Email:</span> {{ project.email || 'N/A' }}</p>
-          <p class="text-gray-700"><span class="font-bold">Teléfono:</span> {{ project.telefono || 'N/A' }}</p>
-          <p class="text-gray-700">
-            <span class="font-bold">Dirección:</span> 
-            <span v-if="loadingDirection">Cargando...</span>
-            <span v-else>{{ projectDirection || 'N/A' }}</span>
-          </p>
+    <!-- Error State -->
+    <div v-else-if="error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-2xl mb-6">
+      <span>{{ error }}</span>
+    </div>
+
+    <!-- Dashboard Content -->
+    <div v-else>
+      <!-- Métricas Clave -->
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+        <!-- Total Empleados -->
+        <div class="neumorphism-card text-center">
+          <div class="text-3xl font-bold text-blue-600 mb-2">{{ dashboardData.totalEmployees || 0 }}</div>
+          <div class="text-gray-600 text-sm">Empleados Activos</div>
+          <div class="text-green-500 text-xs mt-1">{{ dashboardData.employeesTrend || '+0% vs mes anterior' }}</div>
+        </div>
+
+        <!-- Planilla del Mes -->
+        <div class="neumorphism-card text-center">
+          <div class="text-3xl font-bold text-green-600 mb-2">₡{{ (dashboardData.currentPayroll || 0).toLocaleString() }}</div>
+          <div class="text-gray-600 text-sm">Planilla Actual</div>
+          <div class="text-red-500 text-xs mt-1">{{ dashboardData.payrollTrend || '+0% vs mes anterior' }}</div>
+        </div>
+
+        <!-- Departamentos -->
+        <div class="neumorphism-card text-center">
+          <div class="text-3xl font-bold text-purple-600 mb-2">{{ dashboardData.activeDepartments || 0 }}</div>
+          <div class="text-gray-600 text-sm">Departamentos</div>
+          <div class="text-gray-400 text-xs mt-1">{{ dashboardData.departmentsTrend || 'Sin cambios' }}</div>
+        </div>
+
+        <!-- Tareas Pendientes -->
+        <div class="neumorphism-card text-center">
+          <div class="text-3xl font-bold text-orange-600 mb-2">{{ dashboardData.pendingTasks || 0 }}</div>
+          <div class="text-gray-600 text-sm">Tareas Pendientes</div>
+          <div class="text-blue-500 text-xs mt-1">{{ dashboardData.tasksTrend || '0 nuevas hoy' }}</div>
         </div>
       </div>
 
+      <!-- Información de la Empresa y Acciones Rápidas -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+        <!-- Información de la Empresa -->
+        <div class="neumorphism-card p-6 rounded-2xl">
+          <h2 class="text-xl font-semibold mb-4">Información de la Empresa</h2>
+          <div class="space-y-2">
+            <p class="text-gray-700"><span class="font-bold">Nombre:</span> {{ project.nombre || 'N/A' }}</p>
+            <p class="text-gray-700"><span class="font-bold">Cédula Jurídica:</span> {{ project.cedulaJuridica || 'N/A' }}</p>
+            <p class="text-gray-700"><span class="font-bold">Período de Pago:</span> {{ project.periodoPago || 'N/A' }}</p>
+            <p class="text-gray-700"><span class="font-bold">Email:</span> {{ project.email || 'N/A' }}</p>
+            <p class="text-gray-700"><span class="font-bold">Teléfono:</span> {{ project.telefono || 'N/A' }}</p>
+            <p class="text-gray-700">
+              <span class="font-bold">Dirección:</span> 
+              <span v-if="loadingDirection">Cargando...</span>
+              <span v-else>{{ projectDirection || 'N/A' }}</span>
+            </p>
+          </div>
+        </div>
+
+        <!-- Acciones Rápidas -->
+        <div class="neumorphism-card p-6 rounded-2xl">
+          <h2 class="text-xl font-semibold mb-4">Acciones Rápidas</h2>
+          <div class="grid grid-cols-2 gap-4">
+            <button 
+              @click="$emit('section-change', 'employees')" 
+              class="neumorphism-button-normal-light p-4! rounded-xl! text-center w-full h-full"
+            >
+              <div class="text-2xl mb-2">👥</div>
+              <div class="text-sm font-medium">Gestionar Empleados</div>
+            </button>
+
+            <button 
+              @click="$emit('section-change', 'reports')" 
+              class="neumorphism-button-normal-light p-4! rounded-xl! text-center w-full h-full"
+            >
+              <div class="text-2xl mb-2">📊</div>
+              <div class="text-sm font-medium">Ver Reportes</div>
+            </button>
+
+            <button 
+              @click="$emit('section-change', 'benefits')" 
+              class="neumorphism-button-normal-light p-4! rounded-xl! text-center w-full h-full"
+            >
+              <div class="text-2xl mb-2">🎁</div>
+              <div class="text-sm font-medium">Gestionar Beneficios</div>
+            </button>
+
+            <button 
+              @click="$emit('section-change', 'info')" 
+              class="neumorphism-button-normal-light p-4! rounded-xl! text-center w-full h-full"
+            >
+              <div class="text-2xl mb-2">⚙️</div>
+              <div class="text-sm font-medium">Configurar Empresa</div>
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Gráficos -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8 mb-8">
+        <!-- Distribución por Departamentos -->
+        <div class="neumorphism-card p-6 rounded-2xl">
+          <h3 class="text-lg font-semibold mb-4">Empleados por Departamento</h3>
+          <div v-if="departmentStats.length > 0" class="space-y-3">
+            <div v-for="dept in departmentStats" :key="dept.name" class="flex justify-between items-center">
+              <span class="text-gray-700">{{ dept.name }}</span>
+              <span class="font-bold text-blue-600">{{ dept.count }} empleados</span>
+            </div>
+          </div>
+          <div v-else class="h-64 flex items-center justify-center border-2 border-dashed border-gray-300 rounded-lg">
+            <div class="text-center">
+              <div class="text-4xl mb-2">📊</div>
+              <div class="text-gray-500">Sin datos de departamentos</div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Evolución de Planilla -->
+        <div class="neumorphism-card p-6 rounded-2xl">
+          <h3 class="text-lg font-semibold mb-4">Resumen de Planilla</h3>
+          <div class="space-y-4">
+            <div class="flex justify-between items-center">
+              <span class="text-gray-700">Salario Bruto Total:</span>
+              <span class="font-bold text-green-600">₡{{ (dashboardData.currentPayroll || 0).toLocaleString() }}</span>
+            </div>
+            <div class="flex justify-between items-center">
+              <span class="text-gray-700">Promedio por Empleado:</span>
+              <span class="font-bold text-blue-600">
+                ₡{{ dashboardData.totalEmployees > 0 ? Math.round((dashboardData.currentPayroll || 0) / dashboardData.totalEmployees).toLocaleString() : '0' }}
+              </span>
+            </div>
+            <div class="flex justify-between items-center">
+              <span class="text-gray-700">Total Empleados:</span>
+              <span class="font-bold text-purple-600">{{ dashboardData.totalEmployees || 0 }}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Actividades Recientes -->
+      <div class="neumorphism-card p-6 rounded-2xl mb-8">
+        <h3 class="text-lg font-semibold mb-4">Actividades Recientes</h3>
+        <div class="space-y-3">
+          <div v-for="activity in mockRecentActivities" 
+               :key="activity.id" 
+               class="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
+          >
+            <div class="flex items-center">
+              <div class="text-lg mr-3">{{ activity.icon }}</div>
+              <div>
+                <div class="font-medium">{{ activity.title }}</div>
+                <div class="text-sm text-gray-600">{{ activity.description }}</div>
+              </div>
+            </div>
+            <div class="text-xs text-gray-500">{{ activity.time }}</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Próximos Vencimientos -->
       <div class="neumorphism-card p-6 rounded-2xl">
-        <h3 class="text-lg font-semibold mb-4">Empleados por Departamento</h3>
-        <div class="h-64 flex items-center justify-center border-2 border-dashed border-gray-300 rounded-lg">
-          <div class="text-center">
-            <div class="text-4xl mb-2">📊</div>
-            <div class="text-gray-500">Gráfico de Donut</div>
-            <div class="text-xs text-gray-400 mt-1">Próximamente</div>
+        <h3 class="text-lg font-semibold mb-4">Próximos Vencimientos</h3>
+        <div class="space-y-3">
+          <div v-for="reminder in mockUpcomingReminders" 
+               :key="reminder.id" 
+               class="flex items-center justify-between p-3 border-l-4 rounded-lg"
+               :class="{
+                 'border-red-500 bg-red-50': reminder.priority === 'high',
+                 'border-yellow-500 bg-yellow-50': reminder.priority === 'medium',
+                 'border-blue-500 bg-blue-50': reminder.priority === 'low'
+               }"
+          >
+            <div>
+              <div class="font-medium">{{ reminder.title }}</div>
+              <div class="text-sm text-gray-600">{{ reminder.description }}</div>
+            </div>
+            <div class="text-sm font-medium" 
+                 :class="{
+                   'text-red-600': reminder.priority === 'high',
+                   'text-yellow-600': reminder.priority === 'medium',
+                   'text-blue-600': reminder.priority === 'low'
+                 }"
+            >
+              {{ reminder.dueDate }}
+            </div>
           </div>
         </div>
       </div>
@@ -79,14 +214,75 @@ export default {
   emits: ['section-change'],
   data() {
     return {
-      dashboardData: {},
+      dashboardData: {
+        totalEmployees: 0,
+        currentPayroll: 0,
+        activeDepartments: 0,
+        pendingTasks: 0,
+        employeesTrend: '+0% vs mes anterior',
+        payrollTrend: '+0% vs mes anterior',
+        departmentsTrend: 'Sin cambios',
+        tasksTrend: '0 nuevas hoy'
+      },
+      departmentStats: [],
       projectDirection: null,
-      loadingDirection: false
+      loadingDirection: false,
+      loadingDashboard: false,
+      error: null,
+      mockRecentActivities: [
+        {
+          id: 1,
+          icon: '👤',
+          title: 'Nuevo empleado registrado',
+          description: 'Juan Pérez se agregó al sistema',
+          time: 'Hace 2 horas'
+        },
+        {
+          id: 2,
+          icon: '💰',
+          title: 'Planilla procesada',
+          description: 'Planilla de noviembre completada',
+          time: 'Ayer'
+        },
+        {
+          id: 3,
+          icon: '🎁',
+          title: 'Beneficio actualizado',
+          description: 'Seguro médico modificado',
+          time: 'Hace 3 días'
+        }
+      ],
+      mockUpcomingReminders: [
+        {
+          id: 1,
+          title: 'Aguinaldo 2024',
+          description: 'Cálculo y pago de aguinaldo',
+          dueDate: '15 Dic',
+          priority: 'high'
+        },
+        {
+          id: 2,
+          title: 'Reporte mensual CCSS',
+          description: 'Envío de planilla a CCSS',
+          dueDate: '30 Nov',
+          priority: 'medium'
+        },
+        {
+          id: 3,
+          title: 'Revisión de vacaciones',
+          description: 'Actualizar días disponibles',
+          dueDate: '5 Dic',
+          priority: 'low'
+        }
+      ]
     }
   },
   watch: {
     project: {
       handler(newProject) {
+        if (newProject && newProject.id) {
+          this.fetchDashboardData()
+        }
         if (newProject && newProject.idDireccion) {
           this.fetchDirection()
         }
@@ -96,6 +292,72 @@ export default {
     }
   },
   methods: {
+    async fetchDashboardData() {
+      if (!this.project || !this.project.id) return
+
+      try {
+        this.loadingDashboard = true
+        this.error = null
+
+        // Usar el endpoint de dashboard metrics
+        const response = await fetch(apiConfig.endpoints.dashboardMetrics(this.project.id))
+        
+        if (!response.ok) {
+          throw new Error('No se pudieron cargar las métricas del dashboard')
+        }
+
+        const data = await response.json()
+        this.dashboardData = { ...this.dashboardData, ...data }
+        
+        // También cargar empleados para estadísticas de departamentos
+        await this.fetchEmployeeStats()
+        
+        console.log('Dashboard data loaded for project:', this.project.id, this.dashboardData)
+      } catch (err) {
+        console.error('Error loading dashboard data:', err)
+        this.error = err.message || 'Error al cargar el dashboard'
+        
+        // Fallback con datos del proyecto
+        this.dashboardData = {
+          totalEmployees: this.project.activeEmployees || 0,
+          currentPayroll: this.project.monthlyPayroll || 0,
+          activeDepartments: 1,
+          pendingTasks: 0,
+          employeesTrend: '+0% vs mes anterior',
+          payrollTrend: '+0% vs mes anterior',
+          departmentsTrend: 'Sin cambios',
+          tasksTrend: '0 nuevas hoy'
+        }
+      } finally {
+        this.loadingDashboard = false
+      }
+    },
+
+    async fetchEmployeeStats() {
+      try {
+        const response = await fetch(apiConfig.endpoints.projectEmployees(this.project.id))
+        
+        if (response.ok) {
+          const employees = await response.json()
+          const activeEmployees = employees.filter(emp => emp.estado === 'Activo')
+          
+          // Agrupar por departamento
+          const departmentGroups = activeEmployees.reduce((acc, emp) => {
+            const dept = emp.departamento || 'Sin Departamento'
+            acc[dept] = (acc[dept] || 0) + 1
+            return acc
+          }, {})
+
+          this.departmentStats = Object.entries(departmentGroups)
+            .map(([name, count]) => ({ name, count }))
+            .sort((a, b) => b.count - a.count)
+        }
+      } catch (err) {
+        console.error('Error loading employee stats:', err)
+        this.departmentStats = []
+      }
+    },
+
     async fetchDirection() {
       if (!this.project.idDireccion) {
         this.projectDirection = null
@@ -111,8 +373,6 @@ export default {
         }
         
         const direction = await response.json()
-        
-        // Format the complete address
         this.projectDirection = this.formatAddress(direction)
         
         console.log('Direction loaded for project:', this.project.id, direction)

--- a/frontend/src/components/employer/projectDashboard/DashboardProject.vue
+++ b/frontend/src/components/employer/projectDashboard/DashboardProject.vue
@@ -17,173 +17,8 @@
       </div>
 
       <!-- Dashboard Section -->
-      <div v-if="selectedSection === 'dashboard'" class="body">
-        <div class="space-y-[18px]">
-          <h1 class="text-4xl font-bold text-gray-800">Dashboard de Empresa</h1>
-          <div class="w-full h-[10px] mt-2 rounded neumorphism-on-small-item"></div>
-        </div>
-
-        <!-- Métricas Clave -->
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-          <!-- Total Empleados -->
-          <div class="neumorphism-card text-center">
-            <div class="text-3xl font-bold text-blue-600 mb-2">{{ dashboardData.totalEmployees || 25 }}</div>
-            <div class="text-gray-600 text-sm">Empleados Activos</div>
-            <div class="text-green-500 text-xs mt-1">+5% vs mes anterior</div>
-          </div>
-
-          <!-- Planilla del Mes -->
-          <div class="neumorphism-card text-center">
-            <div class="text-3xl font-bold text-green-600 mb-2">₡{{ (dashboardData.currentPayroll || 2500000).toLocaleString() }}</div>
-            <div class="text-gray-600 text-sm">Planilla Actual</div>
-            <div class="text-red-500 text-xs mt-1">+3% vs mes anterior</div>
-          </div>
-
-          <!-- Departamentos -->
-          <div class="neumorphism-card text-center">
-            <div class="text-3xl font-bold text-purple-600 mb-2">{{ dashboardData.activeDepartments || 5 }}</div>
-            <div class="text-gray-600 text-sm">Departamentos</div>
-            <div class="text-gray-400 text-xs mt-1">Sin cambios</div>
-          </div>
-
-          <!-- Tareas Pendientes -->
-          <div class="neumorphism-card text-center">
-            <div class="text-3xl font-bold text-orange-600 mb-2">{{ dashboardData.pendingTasks || 3 }}</div>
-            <div class="text-gray-600 text-sm">Tareas Pendientes</div>
-            <div class="text-blue-500 text-xs mt-1">2 nuevas hoy</div>
-          </div>
-        </div>
-
-        <!-- Información de la Empresa y Acciones Rápidas -->
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          <!-- Información de la Empresa -->
-          <div class="neumorphism-card p-6 rounded-2xl">
-            <h2 class="text-xl font-semibold mb-4">Información de la Empresa</h2>
-            <div class="space-y-2">
-              <p class="text-gray-700"><span class="font-bold">Nombre:</span> {{ project.nombre }}</p>
-              <p class="text-gray-700"><span class="font-bold">Cédula Jurídica:</span> {{ project.cedulaJuridica }}</p>
-              <p class="text-gray-700"><span class="font-bold">Período de Pago:</span> {{ project.periodoPago }}</p>
-              <p class="text-gray-700"><span class="font-bold">Email:</span> {{ project.email }}</p>
-              <p class="text-gray-700"><span class="font-bold">Teléfono:</span> {{ project.telefono }}</p>
-              <p class="text-gray-700"><span class="font-bold">Dirección:</span> {{ project.direccion || 'N/A' }}</p>
-            </div>
-          </div>
-
-          <!-- Acciones Rápidas -->
-          <div class="neumorphism-card p-6 rounded-2xl">
-            <h2 class="text-xl font-semibold mb-4">Acciones Rápidas</h2>
-            <div class="grid grid-cols-2 gap-4">
-              <button 
-                @click="selectedSection = 'employees'" 
-                class="neumorphism-button-normal-light p-4! rounded-xl! text-center w-full h-full"
-              >
-                <div class="text-2xl mb-2">👥</div>
-                <div class="text-sm font-medium">Gestionar Empleados</div>
-              </button>
-
-              <button 
-                @click="selectedSection = 'reports'" 
-                class="neumorphism-button-normal-light p-4! rounded-xl! text-center w-full h-full"
-              >
-                <div class="text-2xl mb-2">📊</div>
-                <div class="text-sm font-medium">Ver Reportes</div>
-              </button>
-
-              <button 
-                @click="selectedSection = 'benefits'" 
-                class="neumorphism-button-normal-light p-4! rounded-xl! text-center w-full h-full"
-              >
-                <div class="text-2xl mb-2">🎁</div>
-                <div class="text-sm font-medium">Gestionar Beneficios</div>
-              </button>
-
-              <button 
-                @click="selectedSection = 'info'" 
-                class="neumorphism-button-normal-light p-4! rounded-xl! text-center w-full h-full"
-              >
-                <div class="text-2xl mb-2">⚙️</div>
-                <div class="text-sm font-medium">Configurar Empresa</div>
-              </button>
-            </div>
-          </div>
-        </div>
-
-        <!-- Gráficos Placeholder -->
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          <!-- Distribución por Departamentos -->
-          <div class="neumorphism-card p-6 rounded-2xl">
-            <h3 class="text-lg font-semibold mb-4">Empleados por Departamento</h3>
-            <div class="h-64 flex items-center justify-center border-2 border-dashed border-gray-300 rounded-lg">
-              <div class="text-center">
-                <div class="text-4xl mb-2">📊</div>
-                <div class="text-gray-500">Gráfico de Donut</div>
-                <div class="text-xs text-gray-400 mt-1">Próximamente</div>
-              </div>
-            </div>
-          </div>
-
-          <!-- Evolución de Planilla -->
-          <div class="neumorphism-card p-6 rounded-2xl">
-            <h3 class="text-lg font-semibold mb-4">Evolución de Planilla (6 meses)</h3>
-            <div class="h-64 flex items-center justify-center border-2 border-dashed border-gray-300 rounded-lg">
-              <div class="text-center">
-                <div class="text-4xl mb-2">📈</div>
-                <div class="text-gray-500">Gráfico de Líneas</div>
-                <div class="text-xs text-gray-400 mt-1">Próximamente</div>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Actividades Recientes -->
-        <div class="neumorphism-card p-6 rounded-2xl">
-          <h3 class="text-lg font-semibold mb-4">Actividades Recientes</h3>
-          <div class="space-y-3">
-            <div v-for="activity in dashboardData.recentActivities || mockRecentActivities" 
-                 :key="activity.id" 
-                 class="flex items-center justify-between p-3 bg-gray-50 rounded-lg"
-            >
-              <div class="flex items-center">
-                <div class="text-lg mr-3">{{ activity.icon }}</div>
-                <div>
-                  <div class="font-medium">{{ activity.title }}</div>
-                  <div class="text-sm text-gray-600">{{ activity.description }}</div>
-                </div>
-              </div>
-              <div class="text-xs text-gray-500">{{ activity.time }}</div>
-            </div>
-          </div>
-        </div>
-
-        <!-- Próximos Vencimientos -->
-        <div class="neumorphism-card p-6 rounded-2xl">
-          <h3 class="text-lg font-semibold mb-4">Próximos Vencimientos</h3>
-          <div class="space-y-3">
-            <div v-for="reminder in dashboardData.upcomingReminders || mockUpcomingReminders" 
-                 :key="reminder.id" 
-                 class="flex items-center justify-between p-3 border-l-4 rounded-lg"
-                 :class="{
-                   'border-red-500 bg-red-50': reminder.priority === 'high',
-                   'border-yellow-500 bg-yellow-50': reminder.priority === 'medium',
-                   'border-blue-500 bg-blue-50': reminder.priority === 'low'
-                 }"
-            >
-              <div>
-                <div class="font-medium">{{ reminder.title }}</div>
-                <div class="text-sm text-gray-600">{{ reminder.description }}</div>
-              </div>
-              <div class="text-sm font-medium" 
-                   :class="{
-                     'text-red-600': reminder.priority === 'high',
-                     'text-yellow-600': reminder.priority === 'medium',
-                     'text-blue-600': reminder.priority === 'low'
-                   }"
-              >
-                {{ reminder.dueDate }}
-              </div>
-            </div>
-          </div>
-        </div>
+      <div v-if="selectedSection === 'dashboard'">
+        <DashboardContent :project="project" @section-change="selectedSection = $event" />
       </div>
 
       <!-- Benefits Section -->
@@ -305,6 +140,7 @@ import EmployeesSection from './EmployeesSection.vue'
 import EmployeesFilter from './EmployeesFilter.vue'
 import EditProjectInfo from './EditProjectInfo.vue'
 import { apiConfig } from '../../../config/api.js'
+import DashboardContent from './DashboardContent.vue'
 
 export default {
   name: 'ProjectDashboard',
@@ -312,6 +148,7 @@ export default {
     MainEmployerHeader,
     DashboardProjectSubHeader,
     PayrollReports,
+    DashboardContent,
     EmployeesSection,
     EmployeesFilter,
     EditProjectInfo
@@ -325,52 +162,6 @@ export default {
       benefits: [],
       selectedSection: 'dashboard',
       dashboardData: {},
-      mockRecentActivities: [
-        {
-          id: 1,
-          icon: '👤',
-          title: 'Nuevo empleado registrado',
-          description: 'Juan Pérez se agregó al sistema',
-          time: 'Hace 2 horas'
-        },
-        {
-          id: 2,
-          icon: '💰',
-          title: 'Planilla procesada',
-          description: 'Planilla de noviembre completada',
-          time: 'Ayer'
-        },
-        {
-          id: 3,
-          icon: '🎁',
-          title: 'Beneficio actualizado',
-          description: 'Seguro médico modificado',
-          time: 'Hace 3 días'
-        }
-      ],
-      mockUpcomingReminders: [
-        {
-          id: 1,
-          title: 'Aguinaldo 2024',
-          description: 'Cálculo y pago de aguinaldo',
-          dueDate: '15 Dic',
-          priority: 'high'
-        },
-        {
-          id: 2,
-          title: 'Reporte mensual CCSS',
-          description: 'Envío de planilla a CCSS',
-          dueDate: '30 Nov',
-          priority: 'medium'
-        },
-        {
-          id: 3,
-          title: 'Revisión de vacaciones',
-          description: 'Actualizar días disponibles',
-          dueDate: '5 Dic',
-          priority: 'low'
-        }
-      ]
     }
   },
   watch: {
@@ -378,7 +169,6 @@ export default {
       handler(newSection) {
         if (newSection) {
           this.selectedSection = newSection;
-          
           this.$router.replace({ 
             path: this.$route.path,
             query: {} 
@@ -406,17 +196,6 @@ export default {
         }
       })
     },
-
-    async fetchCompanies() {
-      try {
-        const response = await fetch(apiConfig.endpoints.project);
-        if (!response.ok) throw new Error('No se pudo cargar las empresas');
-        this.companies = await response.json();
-      } catch (err) {
-        console.error('Error fetching companies:', err);
-      }
-    },
-
     async fetchBenefits() {
       try {
         if (!this.project || !this.project.id) {
@@ -430,29 +209,11 @@ export default {
         this.error = err.message || 'Error al cargar los beneficios';
       }
     },
-
-    async fetchDashboardData() {
-      try {
-        if (!this.project || !this.project.id) return;
-        
-        // Cuando el backend esté listo, descomenta esto:
-        // const response = await fetch(apiConfig.endpoints.employerDashboard(this.project.id));
-        // if (!response.ok) throw new Error('No se pudo cargar el dashboard');
-        // this.dashboardData = await response.json();
-        
-        // Por ahora usa datos mock
-        console.log('Dashboard data loaded for company:', this.project.id);
-      } catch (err) {
-        console.error('Error loading dashboard:', err);
-      }
-    },
-
     onProjectChanged(project) {
       this.project = project;
       this.error = null;
       this.loading = false;
       this.fetchBenefits();
-      this.fetchDashboardData(); // Agregar esta línea
     },
 
     async fetchProject() {
@@ -477,10 +238,9 @@ export default {
     }
   },
   async mounted() {
-    this.fetchCompanies();
     await this.fetchProject();
     this.fetchBenefits();
-    
+  
     if (this.$route.query.section) {
       this.selectedSection = this.$route.query.section;
 

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -4,6 +4,7 @@ const API_BASE_URL = process.env.VUE_APP_API_BASE_URL || 'http://localhost:5011'
 export const apiConfig = {
   baseURL: API_BASE_URL,
   endpoints: {
+    // Dashboard endpoints 
     login: `${API_BASE_URL}/api/login`,
     passwordSetup: `${API_BASE_URL}/api/PasswordSetup/setup`,
     benefit: `${API_BASE_URL}/api/Benefit`,
@@ -26,6 +27,10 @@ export const apiConfig = {
     employeePayrollReportDownloadPdf: (employeeId, payrollId) => `${API_BASE_URL}/api/employees/${employeeId}/payroll-reports/${payrollId}/download/pdf`,
     employeeHistoricalPayrollReport: (employeeId) => `${API_BASE_URL}/api/employees/${employeeId}/payroll-reports/historical`,
     employeeHistoricalPayrollReportDownloadExcel: (employeeId) => `${API_BASE_URL}/api/employees/${employeeId}/payroll-reports/historical/download/excel`,
+
+    // Project Direction endpoint
+    projectDirection: (directionId) => `${API_BASE_URL}/api/Project/direction/${directionId}`,
+
 
     // Work-hours endpoints
     hours: `${API_BASE_URL}/api/hours`,

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -48,8 +48,9 @@ export const apiConfig = {
     verifyEmployerCode: `${API_BASE_URL}/api/employer/verify-email-token`,
     verifyEmployerLinkToken: `${API_BASE_URL}/api/employer/verify-link-token`,
 
-    // ProjectList endpoint
+    // DASHBOARD ENDPOINTS
     projectDashboard: (userId) => `${API_BASE_URL}/api/Project/dashboard/${userId}`,
+    dashboardMetrics: (projectId) => `${API_BASE_URL}/api/Project/${projectId}/dashboard/metrics`,
 
     // Employee endpoints
     projectEmployees: (projectId) => `${API_BASE_URL}/api/Project/${projectId}/employees`,

--- a/utils/PlaniFyQueries.sql
+++ b/utils/PlaniFyQueries.sql
@@ -28,18 +28,19 @@ SELECT * FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_NAME = 'EmpleadorProyecto';
 
 SELECT * FROM PlaniFy.Empresa
 
-DECLARE @EmployerId INT = 25;
 SELECT 
-    e.Id,
-    e.Nombre,
-    e.CedulaJuridica,
-    e.Email,
-    e.PeriodoPago,
-    e.Telefono,
-    e.MaximoBeneficios,
-    e.idEmpleador
-FROM PlaniFy.Empresa AS e
-WHERE e.idEmpleador = @EmployerId;
+    e.idPersona AS Id,
+    CONCAT(p.Nombre, ' ', COALESCE(p.SegundoNombre + ' ', ''), p.Apellidos) AS NombreCompleto,
+    p.Correo,
+    p.Telefono,
+    e.Puesto,
+    e.Departamento,
+    e.Salario,
+    e.TipoContrato
+FROM PlaniFy.Empleado e
+INNER JOIN PlaniFy.Persona p ON p.Id = e.idPersona
+WHERE e.idEmpresa = 17
+AND (e.Estado = 'Activo' OR e.Estado IS NULL);
 
 
 


### PR DESCRIPTION
Se agregó una tarjeta de notificaciones al dashboard de empresas, mostrándola en línea junto a las tarjetas de cédula jurídica, período de pago, empleados activos y rentabilidad. Ahora las notificaciones se obtienen desde el endpoint de métricas y se muestran en la misma fila de información clave de cada empresa.
Además, se implementó un gráfico de pastel para visualizar la distribución de empleados por departamento usando solo CSS (conic-gradient), sin librerías externas, integrando la visualización directamente en el dashboard.
Se ajustaron los estilos y el grid para mantener todas las tarjetas y gráficos alineados en una sola fila y mejorar la experiencia visual del dashboard.

US: https://imparables-iii.atlassian.net/browse/SCRUM-162